### PR TITLE
Fix error 'E185: Cannot find color scheme 'monokai''

### DIFF
--- a/colors/monokai-bold.vim
+++ b/colors/monokai-bold.vim
@@ -31,7 +31,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let colors_name = "monokai"
+let colors_name = "monokai-bold"
 
 function! s:h(group, style)
   let s:ctermformat = "NONE"


### PR DESCRIPTION
Global variable 'colors_name' should be the same as color scheme file
name